### PR TITLE
Fix media-library route

### DIFF
--- a/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
+++ b/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
@@ -64,12 +64,14 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
       $this->isAdminRoute() ||
       $this->isFrontPage($event) ||
       $this->isViewsRoute() ||
+      $this->isMediaLibraryRoute() ||
       $this->contextManager->contextBagIsEmpty()
     ) {
       return;
     }
     $requestedUri = $event->getRequest()->getPathInfo();
     $route_name = $this->currentRouteMatch->getRouteName();
+
     foreach ($this->argumentProcessorManager->getDefinitions() as $definition) {
       if ($definition['route_name'] === $route_name) {
         /** @var \Drupal\alias_subpaths\Plugin\ArgumentProcessorInterface $plugin */
@@ -103,6 +105,17 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
 
   public function isAdminRoute() {
     return $this->adminContext->isAdminRoute($this->currentRouteMatch->getRouteObject());
+  }
+
+  /**
+   * Check if we are in a media library rout, this is a special case because the
+   * media library it uses a custom route that does not belong to admin routes.
+   *
+   * @return bool
+   */
+  public function isMediaLibraryRoute(){
+    $route_object = $this->currentRouteMatch->getRouteObject();
+    return str_starts_with($route_object->getPath(), '/media-library');
   }
 
 }


### PR DESCRIPTION
Issue: https://mrmilu-jira.atlassian.net/browse/HH-181

The error occurs when trying to create a new media on a node, when opening the media_library modal and clicking on "Insert selected". It returns a 404 not found on console log errors on route "/media-library". This route does not belong to the admin category, so we have needed to fix it specifically for this route.

It's related probably with this issue on drupal core: https://www.drupal.org/project/drupal/issues/3365308