### PR TITLE
feature/fix-homepage-404 - Improve Path Handling: Filter Empty Parts in Alias Resolution

### DIFF
--- a/src/AliasSubpathsAliasManager.php
+++ b/src/AliasSubpathsAliasManager.php
@@ -72,6 +72,11 @@ class AliasSubpathsAliasManager {
 
     $path_parts = explode('/', trim($path, '/'));
 
+    // Filter empty parts to avoid issues with leading/trailing slashes.
+    $path_parts = array_filter($path_parts, function ($part) {
+      return !empty($part);
+    });
+
     while (count($path_parts) > 0) {
       $current_alias = '/' . implode('/', $path_parts);
       $current_path = $this->aliasManager->getPathByAlias($current_alias);


### PR DESCRIPTION
# Pull Request: Improve Path Handling in Alias Resolution

This pull request introduces an enhancement to the alias resolution process within the `AliasSubpathsAliasManager` class. The main change is the addition of a filter that removes empty elements from the path parts array before proceeding with alias resolution. This prevents errors or unexpected behavior when paths contain leading, trailing, or consecutive slashes (e.g., `/example//path/`). By ensuring that only non-empty segments are processed, the alias lookup logic becomes more robust and reliable.

## Code Changes

- **AliasSubpathsAliasManager.php**
  - In the `resolveUrl($path)` method, a filtering step was added after splitting the path. This step uses `array_filter` to remove any empty values from the exploded path array, ensuring that only meaningful path segments are considered during resolution.
  - This change prevents issues that could arise from paths with unnecessary slashes, which previously could have resulted in incorrect alias lookups or failures.