### PR TITLE
Avoid 404 for unaliased paths node/x, taxonomy/term/x

### DIFF
--- a/alias_subpaths.services.yml
+++ b/alias_subpaths.services.yml
@@ -25,7 +25,7 @@ services:
 
   alias_subpaths.argument_processor_subscriber:
     class: Drupal\alias_subpaths\EventSubscriber\ArgumentProcessorEventSubscriber
-    arguments: ['@current_route_match', '@alias_subpaths.manager', '@router.admin_context', '@module_handler']
+    arguments: ['@current_route_match', '@alias_subpaths.manager', '@router.admin_context', '@module_handler', '@path_alias.manager']
     tags:
       - { name: event_subscriber }
 

--- a/alias_subpaths.services.yml
+++ b/alias_subpaths.services.yml
@@ -25,7 +25,7 @@ services:
 
   alias_subpaths.argument_processor_subscriber:
     class: Drupal\alias_subpaths\EventSubscriber\ArgumentProcessorEventSubscriber
-    arguments: ['@current_route_match', '@alias_subpaths.manager', '@router.admin_context', '@module_handler', '@path_alias.manager']
+    arguments: ['@current_route_match', '@alias_subpaths.manager', '@router.admin_context', '@module_handler', '@alias_subpaths.alias_manager', '@alias_subpaths.router_manager', '@plugin.manager.argument_processor']
     tags:
       - { name: event_subscriber }
 

--- a/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
+++ b/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
@@ -2,15 +2,17 @@
 
 namespace Drupal\alias_subpaths\EventSubscriber;
 
+use Drupal\alias_subpaths\AliasSubpathsAliasManager;
 use Drupal\alias_subpaths\AliasSubpathsManager;
+use Drupal\alias_subpaths\AliasSubpathsRouterManager;
 use Drupal\alias_subpaths\Exception\InvalidArgumentException;
 use Drupal\alias_subpaths\Exception\NotAllowedArgumentsException;
+use Drupal\alias_subpaths\Plugin\ArgumentProcessorManager;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\AdminContext;
 use Drupal\Core\Routing\CurrentRouteMatch;
-use Drupal\path_alias\AliasManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -56,11 +58,25 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
   private ModuleHandlerInterface $moduleHandler;
 
   /**
-   * The alias manager for looking up the system path.
+   * The alias subpaths alias manager.
    *
-   * @var \Drupal\path_alias\AliasManagerInterface
+   * @var \Drupal\alias_subpaths\AliasSubpathsAliasManager
    */
-  private AliasManagerInterface $aliasManager;
+  private AliasSubpathsAliasManager $aliasSubpathsAliasManager;
+
+  /**
+   * The alias subpaths router manager.
+   *
+   * @var \Drupal\alias_subpaths\AliasSubpathsRouterManager
+   */
+  private AliasSubpathsRouterManager $aliasSubpathsRouterManager;
+
+  /**
+   * The ArgumentProcessorManager service.
+   *
+   * @var \Drupal\alias_subpaths\Plugin\ArgumentProcessorManager
+   */
+  private ArgumentProcessorManager $argumentProcessorManager;
 
   /**
    * Constructs a new ArgumentProcessorEventSubscriber.
@@ -73,21 +89,29 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
    *   The admin context service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler service.
-   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
-   *   The alias manager for looking up the system path.
+   * @param \Drupal\alias_subpaths\AliasSubpathsAliasManager $alias_subpaths_alias_manager
+   *   The alias subpaths alias manager.
+   * @param \Drupal\alias_subpaths\AliasSubpathsRouterManager $alias_subpaths_router_manager
+   *   The alias subpaths router manager.
+   * @param \Drupal\alias_subpaths\Plugin\ArgumentProcessorManager $argument_processor_manager
+   *   The ArgumentProcessorManager service.
    */
   public function __construct(
     CurrentRouteMatch $current_route_match,
     AliasSubpathsManager $alias_subpaths_manager,
     AdminContext $admin_context,
     ModuleHandlerInterface $module_handler,
-    AliasManagerInterface $alias_manager
+    AliasSubpathsAliasManager $alias_subpaths_alias_manager,
+    AliasSubpathsRouterManager $alias_subpaths_router_manager,
+    ArgumentProcessorManager $argument_processor_manager,
   ) {
     $this->currentRouteMatch = $current_route_match;
     $this->adminContext = $admin_context;
     $this->aliasSubpathsManager = $alias_subpaths_manager;
     $this->moduleHandler = $module_handler;
-    $this->aliasManager = $alias_manager;
+    $this->aliasSubpathsAliasManager = $alias_subpaths_alias_manager;
+    $this->aliasSubpathsRouterManager = $alias_subpaths_router_manager;
+    $this->argumentProcessorManager = $argument_processor_manager;
   }
 
   /**
@@ -219,8 +243,16 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
    *   TRUE if the URI is unaliased, FALSE otherwise.
    */
   private function isUnaliasedPath(string $requested_uri): bool {
-    $alias = $this->aliasManager->getPathByAlias($requested_uri);
-    return $alias === $requested_uri;
+    $internal_path = $this->aliasSubpathsAliasManager->resolveUrl($requested_uri);
+    $routeInfo = $this->aliasSubpathsRouterManager->getRouteInfo($internal_path);
+
+    foreach ($this->argumentProcessorManager->getDefinitions() as $definition) {
+      if ($definition['route_name'] === $routeInfo['name']) {
+        return $requested_uri === $internal_path;
+      }
+    }
+
+    return FALSE;
   }
 
 }

--- a/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
+++ b/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
@@ -2,9 +2,12 @@
 
 namespace Drupal\alias_subpaths\EventSubscriber;
 
+use Drupal\alias_subpaths\AliasSubpathsAliasManager;
 use Drupal\alias_subpaths\AliasSubpathsManager;
+use Drupal\alias_subpaths\AliasSubpathsRouterManager;
 use Drupal\alias_subpaths\Exception\InvalidArgumentException;
 use Drupal\alias_subpaths\Exception\NotAllowedArgumentsException;
+use Drupal\alias_subpaths\Plugin\ArgumentProcessorManager;
 use Drupal\Core\Cache\CacheableResponseInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -56,11 +59,25 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
   private ModuleHandlerInterface $moduleHandler;
 
   /**
-   * The alias manager for looking up the system path.
+   * The alias subpaths alias manager.
    *
-   * @var \Drupal\path_alias\AliasManagerInterface
+   * @var \Drupal\alias_subpaths\AliasSubpathsAliasManager
    */
-  private AliasManagerInterface $aliasManager;
+  private AliasSubpathsAliasManager $aliasSubpathsAliasManager;
+
+  /**
+   * The alias subpaths router manager.
+   *
+   * @var \Drupal\alias_subpaths\AliasSubpathsRouterManager
+   */
+  private AliasSubpathsRouterManager $aliasSubpathsRouterManager;
+
+  /**
+   * The ArgumentProcessorManager service.
+   *
+   * @var \Drupal\alias_subpaths\Plugin\ArgumentProcessorManager
+   */
+  private ArgumentProcessorManager $argumentProcessorManager;
 
   /**
    * Constructs a new ArgumentProcessorEventSubscriber.
@@ -73,21 +90,29 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
    *   The admin context service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler service.
-   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
-   *   The alias manager for looking up the system path.
+   * @param \Drupal\alias_subpaths\AliasSubpathsAliasManager $alias_subpaths_alias_manager
+   *   The alias subpaths alias manager.
+   * @param \Drupal\alias_subpaths\AliasSubpathsRouterManager $alias_subpaths_router_manager
+   *   The alias subpaths router manager.
+   * @param \Drupal\alias_subpaths\Plugin\ArgumentProcessorManager $argument_processor_manager
+   *   The ArgumentProcessorManager service.
    */
   public function __construct(
     CurrentRouteMatch $current_route_match,
     AliasSubpathsManager $alias_subpaths_manager,
     AdminContext $admin_context,
     ModuleHandlerInterface $module_handler,
-    AliasManagerInterface $alias_manager
+    AliasSubpathsAliasManager $alias_subpaths_alias_manager,
+    AliasSubpathsRouterManager $alias_subpaths_router_manager,
+    ArgumentProcessorManager $argument_processor_manager,
   ) {
     $this->currentRouteMatch = $current_route_match;
     $this->adminContext = $admin_context;
     $this->aliasSubpathsManager = $alias_subpaths_manager;
     $this->moduleHandler = $module_handler;
-    $this->aliasManager = $alias_manager;
+    $this->aliasSubpathsAliasManager = $alias_subpaths_alias_manager;
+    $this->aliasSubpathsRouterManager = $alias_subpaths_router_manager;
+    $this->argumentProcessorManager = $argument_processor_manager;
   }
 
   /**
@@ -219,8 +244,16 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
    *   TRUE if the URI is unaliased, FALSE otherwise.
    */
   private function isUnaliasedPath(string $requested_uri): bool {
-    $alias = $this->aliasManager->getPathByAlias($requested_uri);
-    return $alias === $requested_uri;
+    $internal_path = $this->aliasSubpathsAliasManager->resolveUrl($requested_uri);
+    $routeInfo = $this->aliasSubpathsRouterManager->getRouteInfo($internal_path);
+
+    foreach ($this->argumentProcessorManager->getDefinitions() as $definition) {
+      if ($definition['route_name'] === $routeInfo['name']) {
+        return $requested_uri === $internal_path;
+      }
+    }
+
+    return FALSE;
   }
 
 }

--- a/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
+++ b/src/EventSubscriber/ArgumentProcessorEventSubscriber.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Routing\AdminContext;
 use Drupal\Core\Routing\CurrentRouteMatch;
+use Drupal\path_alias\AliasManagerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -55,6 +56,13 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
   private ModuleHandlerInterface $moduleHandler;
 
   /**
+   * The alias manager for looking up the system path.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  private AliasManagerInterface $aliasManager;
+
+  /**
    * Constructs a new ArgumentProcessorEventSubscriber.
    *
    * @param \Drupal\Core\Routing\CurrentRouteMatch $current_route_match
@@ -64,17 +72,22 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
    * @param \Drupal\Core\Routing\AdminContext $admin_context
    *   The admin context service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   * @param \Drupal\path_alias\AliasManagerInterface $alias_manager
+   *   The alias manager for looking up the system path.
    */
   public function __construct(
     CurrentRouteMatch $current_route_match,
     AliasSubpathsManager $alias_subpaths_manager,
     AdminContext $admin_context,
     ModuleHandlerInterface $module_handler,
+    AliasManagerInterface $alias_manager
   ) {
     $this->currentRouteMatch = $current_route_match;
     $this->adminContext = $admin_context;
     $this->aliasSubpathsManager = $alias_subpaths_manager;
     $this->moduleHandler = $module_handler;
+    $this->aliasManager = $alias_manager;
   }
 
   /**
@@ -107,6 +120,11 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
     }
 
     $requested_uri = urldecode($request->getPathInfo());
+    // Don't execute alias subpaths processing for unaliased paths to avoid
+    // 404 page.
+    if ($this->isUnaliasedPath($requested_uri)) {
+      return;
+    }
 
     // Add new parameter to current route to determine if the route is a route
     // that we are validating with this module.
@@ -189,6 +207,20 @@ class ArgumentProcessorEventSubscriber implements EventSubscriberInterface {
       return;
     }
     $response->addCacheableDependency($param);
+  }
+
+  /**
+   * Determines if the given requested URI is an unaliased path.
+   *
+   * @param string $requested_uri
+   *   The requested URI to check.
+   *
+   * @return bool
+   *   TRUE if the URI is unaliased, FALSE otherwise.
+   */
+  private function isUnaliasedPath(string $requested_uri): bool {
+    $alias = $this->aliasManager->getPathByAlias($requested_uri);
+    return $alias === $requested_uri;
   }
 
 }


### PR DESCRIPTION
# Avoid 404 for unaliased paths node/{id} and taxonomy/term/{id}

## Summary
This change prevents 404 responses for core entity canonical URLs that are not aliased (for example `node/123` or `taxonomy/term/45`). Instead of treating those unaliased routes as missing, the module now allows core entity routes to resolve normally when there is no path alias.

## Problem
Requests to canonical entity paths with no alias (e.g. `/node/123`) could be incorrectly handled as missing and return a 404. This breaks APIs, internal links, and any direct access to entities on sites that rely on non-aliased entity paths.

## What I changed
- Adjusted the path handling logic so core entity canonical routes (`node/*` and `taxonomy/term/*`) are recognized as valid even when no alias exists.
- Added explicit checks to allow resolution of entity routes by route name / path pattern before returning a 404.
- Preserved existing behavior for aliased paths and non-entity routes.

## Behavioral changes
- Requests to unaliased entity canonical paths (`node/{nid}` and `taxonomy/term/{tid}`) will now be served normally instead of returning 404.
- No change for genuinely missing routes — true 404s are still returned when appropriate.
